### PR TITLE
updated the typo in the example code of pure component

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ const Cmp = (props) => {
   )
 }
 
-export default Cover
+export default Cmp
 ```  
 
 Class Component:


### PR DESCRIPTION
in the readme file, the component name of the pure component is "Cmp" not "Cover".